### PR TITLE
Prismic dependency name change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~4.0",
-        "prismic/php-sdk": "dev-master"
+        "prismic/php-sdk": "1.0.3.*@dev"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Got this error on composer update.

"Problem 1
    - Installation request for adamgoose/prismic-io dev-master -> satisfiable by adamgoose/prismic-io[dev-master].
    - adamgoose/prismic-io dev-master requires prismic/php-sdk dev-master -> no matching package found."
